### PR TITLE
add ressources for wafv2 acl on user agent openvas

### DIFF
--- a/ecs-fargate-service/lb.tf
+++ b/ecs-fargate-service/lb.tf
@@ -76,7 +76,7 @@ resource "aws_alb" "lb" {
 }
 
 resource "aws_wafv2_web_acl_association" "web_acl_association_my_lb" {
-  count      = var.enable_public_lb ? 1 : 0
+  count = var.enable_public_lb && var.waf_acl_arn != "" ? 1 : 0
   depends_on = [aws_alb.lb]
   resource_arn = aws_alb.lb[0].arn
   web_acl_arn  = var.waf_acl_arn

--- a/ecs-fargate-service/lb.tf
+++ b/ecs-fargate-service/lb.tf
@@ -75,110 +75,11 @@ resource "aws_alb" "lb" {
   tags = var.tags
 }
 
-/*resource "aws_wafv2_rule_group" "block-crawlers" {
-  name     = "block-crawlers-rule-${var.service_name}"
-  scope    = "REGIONAL"
-  capacity = 49
-  rule {
-    name     = "rule-1"
-    priority = 1
-
-    action {
-      block {}
-    }
-
-    statement {
-
-      byte_match_statement {
-        positional_constraint = "CONTAINS"
-        search_string         = "openvas-vt"
-      
-
-      field_to_match {
-        single_header {
-          name = "user-agent"
-        }
-      }
-
-      text_transformation {
-        priority = 1
-        type     = "LOWERCASE"
-      }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = false
-      metric_name                = "block-crawlers-rule-metric"
-      sampled_requests_enabled   = false
-    }
-  }
-
-  visibility_config {
-    cloudwatch_metrics_enabled = false
-    metric_name                = "block-crawlers-group-metric"
-    sampled_requests_enabled   = false
-  }
-}*/
-
-resource "aws_wafv2_web_acl" "web-acl-crawlers" {
-  name  = "acl-crawlers-${var.service_name}"
-  scope = "REGIONAL"
-  //depends_on = [aws_wafv2_rule_group.block-crawlers]
-
-  default_action {
-    allow {}
-  }
-
-  rule {
-    name     = "block-crawlers"
-    priority = 1
-
-    action {
-      block {}
-    }
-
-    statement {
-      /*rule_group_reference_statement {
-        arn = aws_wafv2_rule_group.block-crawlers.arn
-      }*/
-      byte_match_statement {
-        positional_constraint = "CONTAINS"
-        search_string         = "openvas-vt"
-      
-
-      field_to_match {
-        single_header {
-          name = "user-agent"
-        }
-      }
-
-      text_transformation {
-        priority = 1
-        type     = "LOWERCASE"
-      }
-    }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "block-crawlers-statement"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  visibility_config {
-    cloudwatch_metrics_enabled = false
-    metric_name                = "web-acl-crawlers"
-    sampled_requests_enabled   = false
-  }
-}
-
 resource "aws_wafv2_web_acl_association" "web_acl_association_my_lb" {
   count      = var.enable_public_lb ? 1 : 0
   depends_on = [aws_alb.lb]
   resource_arn = aws_alb.lb[0].arn
-  web_acl_arn  = aws_wafv2_web_acl.web-acl-crawlers.arn
+  web_acl_arn  = var.waf_acl_arn
 }
 
 resource "aws_alb_target_group" "lb" {

--- a/ecs-fargate-service/lb.tf
+++ b/ecs-fargate-service/lb.tf
@@ -75,6 +75,112 @@ resource "aws_alb" "lb" {
   tags = var.tags
 }
 
+/*resource "aws_wafv2_rule_group" "block-crawlers" {
+  name     = "block-crawlers-rule-${var.service_name}"
+  scope    = "REGIONAL"
+  capacity = 49
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+
+      byte_match_statement {
+        positional_constraint = "CONTAINS"
+        search_string         = "openvas-vt"
+      
+
+      field_to_match {
+        single_header {
+          name = "user-agent"
+        }
+      }
+
+      text_transformation {
+        priority = 1
+        type     = "LOWERCASE"
+      }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "block-crawlers-rule-metric"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "block-crawlers-group-metric"
+    sampled_requests_enabled   = false
+  }
+}*/
+
+resource "aws_wafv2_web_acl" "web-acl-crawlers" {
+  name  = "acl-crawlers-${var.service_name}"
+  scope = "REGIONAL"
+  //depends_on = [aws_wafv2_rule_group.block-crawlers]
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "block-crawlers"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      /*rule_group_reference_statement {
+        arn = aws_wafv2_rule_group.block-crawlers.arn
+      }*/
+      byte_match_statement {
+        positional_constraint = "CONTAINS"
+        search_string         = "openvas-vt"
+      
+
+      field_to_match {
+        single_header {
+          name = "user-agent"
+        }
+      }
+
+      text_transformation {
+        priority = 1
+        type     = "LOWERCASE"
+      }
+    }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "block-crawlers-statement"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "web-acl-crawlers"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "web_acl_association_my_lb" {
+  count      = var.enable_public_lb ? 1 : 0
+  depends_on = [aws_alb.lb]
+  resource_arn = aws_alb.lb[0].arn
+  web_acl_arn  = aws_wafv2_web_acl.web-acl-crawlers.arn
+}
+
 resource "aws_alb_target_group" "lb" {
   count      = var.enable_public_lb ? 1 : 0
   depends_on = [aws_alb.lb]

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -70,6 +70,9 @@ variable "healthcheck_matcher" {
 variable "lb_certificate_arn" {
   default = ""
 }
+variable "waf_acl_arn" {
+  default = ""
+}
 variable "public_lb_dns_zone" {
   default     = "" # TODO default=null ?
   description = "foo.bar."

--- a/test/test_access_logs.tf
+++ b/test/test_access_logs.tf
@@ -17,6 +17,7 @@ module "test_access_logs" {
 
   enable_public_lb       = true
   lb_certificate_arn  = "arn:aws:acm:eu-central-1:812957082909:certificate/b6893e9c-6bc1-4d8b-b845-1604ef1a1704"
+  waf_acl_arn = data.terraform_remote_state.common.outputs.general_acl_arn
   public_lb_dns_zone  = "infra.sencrop.com."
   public_lb_dns_name  = "test-access-logs"
   public_lb_access_logs_bucket = data.terraform_remote_state.common.outputs.access_logs_s3_bucket

--- a/test/test_access_logs.tf
+++ b/test/test_access_logs.tf
@@ -17,7 +17,7 @@ module "test_access_logs" {
 
   enable_public_lb       = true
   lb_certificate_arn  = "arn:aws:acm:eu-central-1:812957082909:certificate/b6893e9c-6bc1-4d8b-b845-1604ef1a1704"
-  waf_acl_arn = data.terraform_remote_state.common.outputs.general_acl_arn
+  waf_acl_arn = data.terraform_remote_state.common.outputs.waf_general_acl_arn
   public_lb_dns_zone  = "infra.sencrop.com."
   public_lb_dns_name  = "test-access-logs"
   public_lb_access_logs_bucket = data.terraform_remote_state.common.outputs.access_logs_s3_bucket

--- a/test/test_names.tf
+++ b/test/test_names.tf
@@ -19,7 +19,7 @@ module "test_names" {
   healthcheck_path    = "/"
   healthcheck_matcher = "200-499"
   lb_certificate_arn  = "arn:aws:acm:eu-central-1:812957082909:certificate/b6893e9c-6bc1-4d8b-b845-1604ef1a1704"
-  waf_acl_arn = data.terraform_remote_state.common.outputs.general_acl_arn
+  waf_acl_arn         = data.terraform_remote_state.common.outputs.waf_general_acl_arn
   public_lb_dns_zone  = "infra.sencrop.com."
   public_lb_dns_name  = "test-names"
 

--- a/test/test_names.tf
+++ b/test/test_names.tf
@@ -19,6 +19,7 @@ module "test_names" {
   healthcheck_path    = "/"
   healthcheck_matcher = "200-499"
   lb_certificate_arn  = "arn:aws:acm:eu-central-1:812957082909:certificate/b6893e9c-6bc1-4d8b-b845-1604ef1a1704"
+  waf_acl_arn = data.terraform_remote_state.common.outputs.general_acl_arn
   public_lb_dns_zone  = "infra.sencrop.com."
   public_lb_dns_name  = "test-names"
 


### PR DESCRIPTION
First step to create a wafv2 acl on the alb to block request coming form user agent "openvas-vt", which corresponds to the pen-test tool OpenVAS from greenbone.

Ideally we would use a rule group resource (like what is commented), but a rule group must be unique, and thus cannot be created in a per-ALB fashion.

As is, the solution is working fine. Might not be worth to invest more on the topic for now.