### PR TITLE
do not destroy service by mistake

### DIFF
--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -214,6 +214,7 @@ resource "aws_ecs_service" "service" {
   # Allow external changes without Terraform plan difference
   lifecycle {
     ignore_changes = [desired_count]
+    prevent_destroy = var.prevent_destroy_service
   }
 
   dynamic "load_balancer" {

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -144,3 +144,7 @@ variable "public_lb_access_logs_bucket" {
   description = "Where to put public LB access logs."
   default = ""
 }
+variable "prevent_destroy_service" {
+  description = "Do not destroy service by mistake"
+  defaut = true
+}


### PR DESCRIPTION
Due to a wrong terraform change, I triggered an unwanted destruction+recreation of an ECS service, incurring some downtime.
I propose to have a `prevent_destroy_service` variable, true by default.
It must be added manually in the service to allow for re-creation:

```
module "foo" {
  source = "github.com/sencrop/terraform-modules//ecs-fargate-service"

  [...]

  prevent_destroy_service = false
}
```

Can also be set for an environment:
```
module "foo" {
  source = "github.com/sencrop/terraform-modules//ecs-fargate-service"

  [...]

  prevent_destroy_service = (terraform.workspace == "production")
}
```



