### PR TITLE
fix: force aws-for-fluent-bit version

### DIFF
--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -95,7 +95,7 @@ locals {
     [] :
     [{
       essential : true,
-      image : "public.ecr.aws/aws-observability/aws-for-fluent-bit:latest",
+      image : "public.ecr.aws/aws-observability/aws-for-fluent-bit:2.19.0",
       name : "log_router",
       firelensConfiguration : {
         type : "fluentbit",


### PR DESCRIPTION
Latest version of aws-for-fluent-bit  seems to have some issues https://github.com/aws/aws-for-fluent-bit/issues/233