### PR TITLE
Fixes for lb_priv and connect jmx

### DIFF
--- a/ecs-fargate-service/lb.tf
+++ b/ecs-fargate-service/lb.tf
@@ -65,6 +65,7 @@ resource "aws_alb" "lb" {
   name_prefix     = "alb-"
   subnets         = var.lb_subnets
   security_groups = [aws_security_group.lb[0].id]
+  idle_timeout    = var.public_lb_idle_timeout
 
   dynamic "access_logs" {
     for_each = var.public_lb_access_logs_bucket == "" ? [] : [1]

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -70,6 +70,7 @@ resource "aws_alb" "lb_priv" {
   subnets         = var.lb_private_subnets
   security_groups = [aws_security_group.lb_priv[0].id]
   internal        = true
+  idle_timeout    = 180
 
   dynamic "access_logs" {
     for_each = var.private_lb_access_logs_bucket == "" ? [] : [1]

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -70,7 +70,7 @@ resource "aws_alb" "lb_priv" {
   subnets         = var.lb_private_subnets
   security_groups = [aws_security_group.lb_priv[0].id]
   internal        = true
-  idle_timeout    = 180
+  idle_timeout    = var.private_lb_idle_timeout
 
   dynamic "access_logs" {
     for_each = var.private_lb_access_logs_bucket == "" ? [] : [1]

--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -118,6 +118,20 @@ locals {
     }]
   )
 
+  availabilty_side_car_task = (
+    var.availability_sidecar_enable == false ?
+    [] :
+    [{
+      image : var.availability_sidecar_image,
+      name : "availability-tools",
+      networkMode : "awsvpc"
+      environment : [
+        { name : "IS_CONNECT_JMX", value : "true" },
+        { name : "DD_ENV", value : lower(terraform.workspace) }
+      ]
+    }]
+  )
+
   datadog_agent_task = (
     var.enable_datadog_agent ?
     [{
@@ -194,7 +208,7 @@ resource "aws_ecs_task_definition" "task" {
   // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
   container_definitions = jsonencode(
     flatten(
-      [local.main_task, local.side_car_task, local.fluentbit_task, local.datadog_agent_task]
+      [local.main_task, local.side_car_task, local.availabilty_side_car_task, local.fluentbit_task, local.datadog_agent_task]
     )
   )
 

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -57,6 +57,12 @@ variable "side_car_image" {
 variable "side_car_name" {
   default = ""
 }
+variable "availability_sidecar_enable" {
+  default = false
+}
+variable "availability_sidecar_image" {
+  default = "812957082909.dkr.ecr.eu-central-1.amazonaws.com/observability-tools:8c06fd0"
+}
 variable "healthcheck_path" {
   default = ""
 }

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -92,6 +92,9 @@ variable "public_lb_dns_zone" {
 variable "public_lb_dns_name" {
   default = ""
 }
+variable "public_lb_idle_timeout" {
+  default = 60
+}
 variable "enable_public_lb" {
   default = true
 }
@@ -181,4 +184,7 @@ variable "private_lb_dns_zone" {
 }
 variable "private_lb_dns_name" {
   default = ""
+}
+variable "private_lb_idle_timeout" {
+  default = 60
 }


### PR DESCRIPTION
This PR tackles two topics :
    - The default idle_timeout of the privates load balancers is increased to 180sec from 60, allowing longer requests (most notably on demeter-batch) to success
    - The possibility to have  a new sidecar image of availability tools deployed alongside a main task in order to get container specific metrics, including during auto upscaling and downscaling