### PR TITLE
feat(datadog-agent): expose the dd_apm_ignore_ressources variable

### DIFF
--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -145,6 +145,7 @@ locals {
         { name : "ECS_FARGATE", value : "true" },
         { name : "DD_TAGS", value : join(" ", [for k, v in var.tags : format("%s:%s", k, v)]) },
         { name : "DD_APM_ENABLED", value : tostring(var.enable_datadog_agent_apm) },
+        { name : "DD_APM_IGNORE_RESOURCES", value : join(",", var.datadog_apm_ignore_ressources)}
         { name : "DD_APM_NON_LOCAL_TRAFFIC", value : tostring(var.enable_datadog_non_local_apm) },
         { name : "DD_ENV", value : lower(terraform.workspace) },
         { name : "DD_LOGS_INJECTION", value : tostring(var.enable_datadog_logs_injection) }

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -159,6 +159,10 @@ variable "enable_datadog_non_local_apm" {
   default     = false
   description = "To enable APM data collection in datadog agent with APM features."
 }
+variable "datadog_apm_ignore_ressources" {
+  default = []
+  description = "List of ressources (span names) to ignore in the APM. See https://docs.datadoghq.com/tracing/guide/ignoring_apm_resources/"
+}
 variable "enable_datadog_logs_injection" {
   default     = false
   description = "To inject trace IDs, span IDs, env, service, and version in the logs. See https://docs.datadoghq.com/tracing/connect_logs_and_traces/"


### PR DESCRIPTION
Expose the dd_apm_ignore_ressources variable in the module in order to be able to ignore some spans that have little to no interest to us in the APM.