### PR TITLE
switch to shared lb

### DIFF
--- a/ecs-fargate-service/lb.tf
+++ b/ecs-fargate-service/lb.tf
@@ -1,5 +1,6 @@
-# Application Load Balancer, in public zone, with https endpoint and publing name
-#   all these resources are enabled depending on var.enable_public_lb 
+# all there resources are obsolete, and will be removed once all services 
+#   are using shared LBs
+
 
 resource "aws_security_group" "lb" {
   count = var.enable_public_lb ? 1 : 0
@@ -29,34 +30,6 @@ resource "aws_security_group" "lb" {
   }
 }
 
-# Incoming traffic to the service from LB
-resource "aws_security_group" "lb_to_service" {
-  count = var.enable_public_lb ? 1 : 0
-
-  name_prefix = "task-"
-  description = "inbound access from the LB for ${var.service_name}"
-  vpc_id      = var.vpc_id
-
-  ingress {
-    protocol        = "tcp"
-    from_port       = var.port
-    to_port         = var.port
-    security_groups = [aws_security_group.lb[0].id]
-  }
-
-  egress {
-    protocol    = "-1"
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = var.tags
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
 
 # create LB
 resource "aws_alb" "lb" {
@@ -122,22 +95,3 @@ resource "aws_alb_listener" "lb" {
   }
 }
 
-data "aws_route53_zone" "public_lb_dns_zone" {
-  count = var.enable_public_lb ? 1 : 0
-
-  name         = var.public_lb_dns_zone
-  private_zone = false
-}
-
-resource "aws_route53_record" "dns_record" {
-  count = var.enable_public_lb ? 1 : 0
-
-  zone_id = data.aws_route53_zone.public_lb_dns_zone[0].zone_id
-  name    = var.public_lb_dns_name
-  type    = "CNAME"
-  ttl     = "300"
-  records = [aws_alb.lb[0].dns_name]
-
-  # teerraform tends to mess with records destruction/recreation
-  allow_overwrite = true
-}

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -126,22 +126,3 @@ resource "aws_alb_listener" "lb_priv" {
   }
 }
 
-data "aws_route53_zone" "private_lb_dns_zone" {
-  count = var.enable_private_lb ? 1 : 0
-
-  name         = var.private_lb_dns_zone
-  private_zone = true
-}
-
-resource "aws_route53_record" "private_dns_record" {
-  count = var.enable_private_lb ? 1 : 0
-
-  zone_id = data.aws_route53_zone.private_lb_dns_zone[0].zone_id
-  name    = var.private_lb_dns_name
-  type    = "CNAME"
-  ttl     = "300"
-  records = [aws_alb.lb_priv[0].dns_name]
-
-  # teerraform tends to mess with records destruction/recreation
-  allow_overwrite = true
-}

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -1,5 +1,5 @@
-# Application Load Balancer, in private zone, with dsn name
-#   all these resources are enabled depending on var.enable_private_lb 
+# all there resources are obsolete, and will be removed once all services 
+#   are using shared LBs
 
 data "aws_vpc" "vpc" {
   id = var.vpc_id

--- a/ecs-fargate-service/listener_private.tf
+++ b/ecs-fargate-service/listener_private.tf
@@ -1,0 +1,102 @@
+
+# Incoming traffic to the service from LB
+resource "aws_security_group_rule" "lb_priv_to_service_ingress_legacy_lb" {
+  count = var.enable_private_lb ? 1 : 0
+  security_group_id = aws_security_group.service.id
+  type = "ingress"
+  protocol        = "tcp"
+  from_port       = 80
+  to_port         = 80
+  source_security_group_id = aws_security_group.lb_priv[0].id
+}
+resource "aws_security_group_rule" "lb_priv_to_service_ingress_shared_lb" {
+  count = var.enable_private_lb ? 1 : 0
+  security_group_id = aws_security_group.service.id
+  type = "ingress"
+  protocol        = "tcp"
+  from_port       = var.port
+  to_port         = var.port
+  source_security_group_id = var.private_alb_sg_id
+}
+
+resource "aws_alb_target_group" "private_lb" {
+  count      = var.enable_private_lb ? 1 : 0
+
+  name_prefix = "task-"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path     = var.healthcheck_path
+    interval = var.healthcheck_interval
+    timeout  = var.healthcheck_timeout
+    matcher  = var.healthcheck_matcher
+    unhealthy_threshold = var.healthcheck_unhealthy_threshold
+  }
+
+  deregistration_delay = var.deregistration_delay
+  
+  tags = var.tags
+}
+
+resource "aws_alb_listener" "private_lb" {
+  count = var.enable_private_lb ? 1 : 0
+
+  load_balancer_arn = var.private_alb_arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = aws_alb_target_group.private_lb[0].arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener_rule" "private_lb_listener" {
+  count = var.enable_private_lb ? 1 : 0
+
+  listener_arn = aws_alb_listener.private_lb[0].arn
+  
+  action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.private_lb[0].arn
+  }
+
+  condition {
+    host_header {
+      values = [
+        trimsuffix("${var.private_lb_dns_name}.${var.private_lb_dns_zone}", ".")
+      ]
+    }
+  }
+
+  tags = var.tags
+}
+
+data "aws_route53_zone" "private_lb_dns_zone" {
+  count = var.enable_private_lb ? 1 : 0
+
+  name         = var.private_lb_dns_zone
+  private_zone = false
+}
+
+data "aws_alb" "shared_private_lb" {
+  count = var.enable_private_lb ? 1 : 0
+
+  arn = var.private_alb_arn
+}
+
+resource "aws_route53_record" "private_dns_record" {
+  count = var.enable_private_lb ? 1 : 0
+
+  zone_id = data.aws_route53_zone.private_lb_dns_zone[0].zone_id
+  name    = var.private_lb_dns_name
+  type    = "CNAME"
+  ttl     = "300"
+  records = [aws_alb.shared_private_lb[0].dns_name]
+
+  # terraform tends to mess with records destruction/recreation
+  allow_overwrite = true
+}

--- a/ecs-fargate-service/listener_private.tf
+++ b/ecs-fargate-service/listener_private.tf
@@ -79,7 +79,7 @@ data "aws_route53_zone" "private_lb_dns_zone" {
   count = var.enable_private_lb ? 1 : 0
 
   name         = var.private_lb_dns_zone
-  private_zone = false
+  private_zone = true
 }
 
 data "aws_alb" "shared_private_lb" {
@@ -95,7 +95,7 @@ resource "aws_route53_record" "private_dns_record" {
   name    = var.private_lb_dns_name
   type    = "CNAME"
   ttl     = "300"
-  records = [aws_alb.shared_private_lb[0].dns_name]
+  records = [data.aws_alb.shared_private_lb[0].dns_name]
 
   # terraform tends to mess with records destruction/recreation
   allow_overwrite = true

--- a/ecs-fargate-service/listener_public.tf
+++ b/ecs-fargate-service/listener_public.tf
@@ -96,7 +96,7 @@ resource "aws_route53_record" "dns_record" {
   name    = var.public_lb_dns_name
   type    = "CNAME"
   ttl     = "300"
-  records = [data.shared_public_lb[0].dns_name]
+  records = [data.aws_alb.shared_public_lb[0].dns_name]
 
   # terraform tends to mess with records destruction/recreation
   allow_overwrite = true

--- a/ecs-fargate-service/listeners.tf
+++ b/ecs-fargate-service/listeners.tf
@@ -1,31 +1,31 @@
 
 # Incoming traffic to the service from LB
-resource "aws_security_group" "lb_to_service" {
+resource "aws_security_group_rule" "lb_to_service_ingress_legacy_lb" {
   count = var.enable_public_lb ? 1 : 0
-
-  name_prefix = "task-"
-  description = "inbound access from public LB for ${var.service_name}"
-  vpc_id      = var.vpc_id
-
-  ingress {
-    protocol        = "tcp"
-    from_port       = var.port
-    to_port         = var.port
-    security_groups = [var.public_alb_sg_id, aws_security_group.lb[0].id]
-  }
-
-  egress {
-    protocol    = "-1"
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = var.tags
-
-  lifecycle {
-    create_before_destroy = true
-  }
+  security_group_id = aws_security_group.service.id
+  type = "ingress"
+  protocol        = "tcp"
+  from_port       = var.port
+  to_port         = var.port
+  source_security_group_id = aws_security_group.lb[0].id
+}
+resource "aws_security_group_rule" "lb_to_service_ingress_shared_lb" {
+  count = var.enable_public_lb ? 1 : 0
+  security_group_id = aws_security_group.service.id
+  type = "ingress"
+  protocol        = "tcp"
+  from_port       = var.port
+  to_port         = var.port
+  source_security_group_id = var.public_alb_sg_id
+}
+resource "aws_security_group_rule" "lb_to_service_egress" {
+  count = var.enable_public_lb ? 1 : 0
+  security_group_id = aws_security_group.service.id
+  type = "egress"
+  protocol    = "-1"
+  from_port   = 0
+  to_port     = 0
+  cidr_blocks = ["0.0.0.0/0"]
 }
 
 resource "aws_alb_target_group" "public_lb" {

--- a/ecs-fargate-service/listeners.tf
+++ b/ecs-fargate-service/listeners.tf
@@ -1,0 +1,105 @@
+
+# Incoming traffic to the service from LB
+resource "aws_security_group" "lb_to_service" {
+  count = var.enable_public_lb ? 1 : 0
+
+  name_prefix = "task-"
+  description = "inbound access from public LB for ${var.service_name}"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = var.port
+    to_port         = var.port
+    security_groups = [var.public_alb_sg_id, aws_security_group.lb[0].id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_alb_target_group" "public_lb" {
+  count      = var.enable_public_lb ? 1 : 0
+
+  name_prefix = "task-"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path     = var.healthcheck_path
+    interval = var.healthcheck_interval
+    timeout  = var.healthcheck_timeout
+    matcher  = var.healthcheck_matcher
+  }
+
+  deregistration_delay = var.deregistration_delay
+  
+  tags = var.tags
+}
+
+resource "aws_alb_listener" "public_lb_listener" {
+  count = var.enable_public_lb ? 1 : 0
+
+  load_balancer_arn = var.public_alb_arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = var.lb_certificate_arn
+
+  default_action {
+    target_group_arn = aws_alb_target_group.public_lb[0].arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener_rule" "public_lb_listener" {
+  count = var.enable_public_lb ? 1 : 0
+
+  listener_arn = aws_alb_listener.public_lb_listener[0].arn
+  
+  action {
+    type             = "forward"
+    target_group_arn = aws_alb_target_group.public_lb[0].arn
+  }
+
+  condition {
+    host_header {
+      values = ["${var.public_lb_dns_name}.*"]
+    }
+  }
+
+  tags = var.tags
+}
+
+
+data "aws_route53_zone" "public_lb_dns_zone" {
+  count = var.enable_public_lb ? 1 : 0
+
+  name         = var.public_lb_dns_zone
+  private_zone = false
+}
+
+resource "aws_route53_record" "dns_record" {
+  count = var.enable_public_lb ? 1 : 0
+
+  zone_id = data.aws_route53_zone.public_lb_dns_zone[0].zone_id
+  name    = var.public_lb_dns_name
+  type    = "CNAME"
+  ttl     = "300"
+  records = [aws_alb.lb[0].dns_name]
+
+  # terraform tends to mess with records destruction/recreation
+  allow_overwrite = true
+}

--- a/ecs-fargate-service/outputs.tf
+++ b/ecs-fargate-service/outputs.tf
@@ -2,14 +2,6 @@ output "url" {
   value = "https://${var.public_lb_dns_name}.${trim(var.public_lb_dns_zone, ".")}"
 }
 
-output "alb_zone_id" {
-  value = (var.enable_public_lb ? aws_alb.lb[0].zone_id : "") 
-}
-
-output "alb_dns_name" {
-  value = (var.enable_public_lb ? aws_alb.lb[0].dns_name : "")
-}
-
 output "ecs_task_role_arn" {
   value = aws_iam_role.task_role.arn
 }

--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -262,7 +262,12 @@ resource "aws_ecs_service" "service" {
   }
 
   dynamic "load_balancer" {
-    for_each = concat(aws_alb_target_group.lb[*].arn, aws_alb_target_group.lb_priv[*].arn)
+    for_each = concat(
+      aws_alb_target_group.lb[*].arn, 
+      aws_alb_target_group.lb_priv[*].arn,
+      aws_alb_target_group.public_lb[*].arn,
+      aws_alb_target_group.private_lb[*].arn
+    )
     content {
       target_group_arn = load_balancer.value
       container_name   = var.service_name

--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -226,6 +226,15 @@ resource "aws_security_group" "service" {
     create_before_destroy = true
   }
 }
+resource "aws_security_group_rule" "service_default_egress" {
+  security_group_id = aws_security_group.service.id
+  type = "egress"
+  protocol    = "-1"
+  from_port   = 0
+  to_port     = 0
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
 
 # service definition
 resource "aws_ecs_service" "service" {

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -90,10 +90,11 @@ variable "waf_acl_arn" {
 }
 variable "public_lb_dns_zone" {
   default     = "" 
-  description = "foo.bar."
+  description = "Zone in which the CNAME of the service will be setup, eg. foo.bar."
 }
 variable "public_lb_dns_name" {
   default = ""
+  description = "CNAME of the service, pointing to LB"
 }
 variable "public_lb_idle_timeout" {
   default = 60
@@ -187,10 +188,11 @@ variable "private_lb_access_logs_bucket" {
 }
 variable "private_lb_dns_zone" {
   default     = "" 
-  description = "foo.bar."
+  description = "Zone in which the CNAME of the service will be setup, eg. foo.bar."
 }
 variable "private_lb_dns_name" {
   default = ""
+  description = "CNAME of the service, pointing to private LB"
 }
 variable "private_lb_idle_timeout" {
   default = 60
@@ -209,10 +211,20 @@ variable "datadog_mapper" {
 
 variable "public_alb_arn" {
   default = ""
-  description = "ALB to attach public listeners to"
+  description = "Shared public ALB to attach listeners to"
 }
 
 variable "public_alb_sg_id" {
   default = ""
   description = "SG of the public ALB to allow traffic from it"
+}
+
+variable "private_alb_arn" {
+  default = ""
+  description = "Shared private ALB to attach listeners to"
+}
+
+variable "private_alb_sg_id" {
+  default = ""
+  description = "SG of the private ALB to allow traffic from it"
 }

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -207,3 +207,12 @@ variable "datadog_mapper" {
   description = "Where to put some inline mappings between metrics emitted by some software and Datadog. Used only for Airflow as of now."
 }
 
+variable "public_alb_arn" {
+  default = ""
+  description = "ALB to attach public listeners to"
+}
+
+variable "public_alb_sg_id" {
+  default = ""
+  description = "SG of the public ALB to allow traffic from it"
+}

--- a/test/context.tf
+++ b/test/context.tf
@@ -36,3 +36,4 @@ resource "aws_security_group" "test-sg" {
 data "aws_ssm_parameter" "datadog_api_key" {
   name = "/tf/${terraform.workspace}/datadog/api_key"
 }
+

--- a/test/test_access_logs.tf
+++ b/test/test_access_logs.tf
@@ -15,11 +15,11 @@ module "test_access_logs" {
 
   additional_security_groups = [aws_security_group.test-sg.id]
 
-  enable_public_lb       = true
-  lb_certificate_arn  = "arn:aws:acm:eu-central-1:812957082909:certificate/b6893e9c-6bc1-4d8b-b845-1604ef1a1704"
-  waf_acl_arn = data.terraform_remote_state.common.outputs.waf_general_acl_arn
-  public_lb_dns_zone  = "infra.sencrop.com."
-  public_lb_dns_name  = "test-access-logs"
+  enable_public_lb             = true
+  lb_certificate_arn           = "arn:aws:acm:eu-central-1:812957082909:certificate/b6893e9c-6bc1-4d8b-b845-1604ef1a1704"
+  waf_acl_arn                  = data.terraform_remote_state.common.outputs.waf_general_acl_arn
+  public_lb_dns_zone           = "infra.sencrop.com."
+  public_lb_dns_name           = "test-access-logs"
   public_lb_access_logs_bucket = data.terraform_remote_state.common.outputs.access_logs_s3_bucket
 
   enable_local_discovery = false

--- a/test/test_cloudwatch.tf
+++ b/test/test_cloudwatch.tf
@@ -23,6 +23,6 @@ module "test_cloudwatch" {
     Application = "foo"
   }
 
-  logs            = "cloudwatch"
+  logs = "cloudwatch"
 }
 

--- a/test/test_names.tf
+++ b/test/test_names.tf
@@ -16,6 +16,8 @@ module "test_names" {
   additional_security_groups = [aws_security_group.test-sg.id]
 
   enable_public_lb    = true
+  public_alb_arn      = data.terraform_remote_state.common.outputs.common_public_alb_arn
+  public_alb_sg_id    = data.terraform_remote_state.common.outputs.common_public_alb_sg_id
   healthcheck_path    = "/"
   healthcheck_matcher = "200-499"
   lb_certificate_arn  = "arn:aws:acm:eu-central-1:812957082909:certificate/b6893e9c-6bc1-4d8b-b845-1604ef1a1704"

--- a/test/test_names.tf
+++ b/test/test_names.tf
@@ -18,10 +18,12 @@ module "test_names" {
   enable_public_lb    = true
   public_alb_arn      = data.terraform_remote_state.common.outputs.common_public_alb_arn
   public_alb_sg_id    = data.terraform_remote_state.common.outputs.common_public_alb_sg_id
+  
   healthcheck_path    = "/"
   healthcheck_matcher = "200-499"
   lb_certificate_arn  = "arn:aws:acm:eu-central-1:812957082909:certificate/b6893e9c-6bc1-4d8b-b845-1604ef1a1704"
   waf_acl_arn         = data.terraform_remote_state.common.outputs.waf_general_acl_arn
+  
   public_lb_dns_zone  = "infra.sencrop.com."
   public_lb_dns_name  = "test-names"
 

--- a/test/test_private_lb.tf
+++ b/test/test_private_lb.tf
@@ -26,8 +26,8 @@ module "test_private_lb" {
   lb_private_subnets  = data.terraform_remote_state.common.outputs.common_vpc_private_subnets
   healthcheck_path    = "/"
   healthcheck_matcher = "200-499"
-  private_lb_dns_zone  = "${terraform.workspace}.priv."
-  private_lb_dns_name  = "test-private-lb"
+  private_lb_dns_zone = "${terraform.workspace}.priv."
+  private_lb_dns_name = "test-private-lb"
 
   tags = {
     Environment = terraform.workspace

--- a/test/test_private_lb.tf
+++ b/test/test_private_lb.tf
@@ -24,6 +24,9 @@ module "test_private_lb" {
 
   enable_private_lb   = true
   lb_private_subnets  = data.terraform_remote_state.common.outputs.common_vpc_private_subnets
+  private_alb_arn     = data.terraform_remote_state.common.outputs.common_priv_alb_arn
+  private_alb_sg_id   = data.terraform_remote_state.common.outputs.common_priv_alb_sg_id
+
   healthcheck_path    = "/"
   healthcheck_matcher = "200-499"
   private_lb_dns_zone = "${terraform.workspace}.priv."


### PR DESCRIPTION
This PR add a new listener for the service to the common shared LB, but keeps the existing non-shared LB, to avoid service disruption. It also update the CNAME to point to this new listener.

When all services will be migrated, I'll then remove the non-shared LB with #15.

Note: I do not plan to rely on a versioning of this module, I plan to manually update all services after this PR is merged. (and again after removal of unused LBs)

I tested this change by creating a test service in preproduction (using master version of this module), then updated it using this PR. The terraform changes are limited, and it did not see any disruption. 

Once merged, the various service definitions must be updated with variables:
```
public_alb_arn = data.terraform_remote_state.common.outputs.common_public_alb_arn
public_alb_sg_id = data.terraform_remote_state.common.outputs.common_public_alb_sg_id
# and/or
private_alb_arn = data.terraform_remote_state.common.outputs.common_priv_alb_arn
private_alb_sg_id = data.terraform_remote_state.common.outputs.common_priv_alb_sg_id
```

TODO list of services:
- [ ] airflow-flower
- [ ] airflow-worker
- [ ] airflow-webserver
- [ ] airflow-scheduler
- [ ] sencrop-kutt
- [ ] sencrop-guide
- [ ] dsp-connect
- [ ] dsp-connect-history
- [ ] mapviz-back
- [ ] mapviz-front
- [ ] demeter
- [ ] observability-tools
- [ ] sencrop-api-nestjs
- [ ] data-capture

in addition
- [ ]   infra-commons must be updated in production (creation of LBs)