### PR TITLE
Add support for secrets definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Capabilities:
 - service can optionaly be created inside a given security group (for example to be designated as allowed ingress in a DB security group)
 - autoscale can be activated in target tracking mode, on CPU average utilization
 - an IAM policy can be given to the task (for example, to have role-based access to s3)
+- when defined secrets will automatically update the ECS task execution role to allow secret injection
 
 
 
@@ -33,7 +34,6 @@ Outputs:
 
 
 Future improvements:
-- better handling of secrets using https://aws.amazon.com/premiumsupport/knowledge-center/ecs-data-security-container-task/ 
 - more outputs
 
 

--- a/ecs-fargate-service/policies/assume/ecs-tasks.json
+++ b/ecs-fargate-service/policies/assume/ecs-tasks.json
@@ -1,0 +1,13 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ecs-tasks.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}

--- a/ecs-fargate-service/policies/read-task-secrets.tftpl
+++ b/ecs-fargate-service/policies/read-task-secrets.tftpl
@@ -1,0 +1,29 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParameter",
+                "ssm:GetParameters"
+            ],
+            "Resource": [
+                %{ for p in ssm_parameters ~}
+                "arn:aws:ssm:${region}:${account_id}:parameter${p}"
+                %{ endfor ~}
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+              "kms:Decrypt"
+            ],
+            "Resource": "*",
+            "Condition": {
+              "StringLike": {
+                "kms:RequestAlias": "alias/aws/ssm"
+              }
+            }
+        }
+     ]
+}

--- a/ecs-fargate-service/policies/read-task-secrets.tftpl
+++ b/ecs-fargate-service/policies/read-task-secrets.tftpl
@@ -8,9 +8,7 @@
                 "ssm:GetParameters"
             ],
             "Resource": [
-                %{ for p in ssm_parameters ~}
-                "arn:aws:ssm:${region}:${account_id}:parameter${p}"
-                %{ endfor ~}
+                ${join(",\n", formatlist("\"arn:aws:ssm:%s:%s:parameter%s\"", region, account_id, ssm_parameters))}
             ]
         },
         {

--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -3,6 +3,7 @@ locals {
   cluster_name = reverse(split("/", var.ecs_cluster_id))[0]
   account_id = data.aws_caller_identity.current.account_id
   region = data.aws_region.current.name
+  needs_execution_role = (length(var.secrets) > 0 ? true : false)
 }
 
 resource "aws_cloudwatch_log_group" "service_log" {
@@ -11,6 +12,10 @@ resource "aws_cloudwatch_log_group" "service_log" {
   name              = "/ecs/${local.cluster_name}/${var.service_name}_task"
   retention_in_days = 3
   tags              = var.tags
+}
+
+data "aws_iam_role" "ecs_role" {
+  name = "ecsTaskExecutionRole"
 }
 
 data "aws_caller_identity" "current" {}
@@ -181,14 +186,16 @@ resource "aws_iam_role_policy_attachment" "custom_policy" {
 }
 
 resource "aws_iam_role" "execution_role" {
+  count = (local.needs_execution_role ? 1 : 0)
   name = "${var.service_name}-${terraform.workspace}-task-execution-role"
   assume_role_policy = file("${path.module}/policies/assume/ecs-tasks.json")
   managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }
 
 resource "aws_iam_role_policy" "read-task-secrets" {
+  count = (length(var.secrets) > 0 ? 1 : 0)
   name = "${var.service_name}-${terraform.workspace}-secrets"
-  role = aws_iam_role.execution_role.id
+  role = aws_iam_role.execution_role[0].id
   policy = templatefile("${path.module}/policies/read-task-secrets.tftpl", {region: local.region, account_id: local.account_id, ssm_parameters: values(var.secrets)})
 }
 
@@ -199,7 +206,7 @@ resource "aws_ecs_task_definition" "task" {
   family                   = "${var.service_name}-${terraform.workspace}"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  execution_role_arn       = aws_iam_role.execution_role.arn
+  execution_role_arn       = local.needs_execution_role ? aws_iam_role.execution_role[0].arn : data.aws_iam_role.ecs_role.arn
   task_role_arn            = aws_iam_role.task_role.arn
 
   cpu    = var.cpu

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -48,6 +48,10 @@ variable "env_vars" {
   default = {}
   type    = map(string)
 }
+variable "secrets" {
+  default = {}
+  type    = map(string)
+}
 variable "command" {
   default = []
 }

--- a/test/context.tf
+++ b/test/context.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "= 0.14.11"
+  required_version = "= 1.0.11"
 }
 
 data "terraform_remote_state" "common" {

--- a/test/test_secrets.tf
+++ b/test/test_secrets.tf
@@ -1,0 +1,30 @@
+module "test_secrets" {
+  source = "../ecs-fargate-service"
+
+  service_name = "test-secrets"
+  image        = "jmalloc/echo-server"
+  cpu          = 256
+  mem          = 512
+  port         = 8080
+
+  secrets = {
+    "MY_LITTLE_SECRET" : "/tf/test/my-little-secret",
+    "MY_BIG_SECRET"    : "/tf/test/my-big-secret"
+
+  }
+
+  ecs_cluster_id = data.terraform_remote_state.common.outputs.main_ecs_cluster_id
+  vpc_id         = data.terraform_remote_state.common.outputs.common_vpc_id
+  lb_subnets     = data.terraform_remote_state.common.outputs.common_vpc_public_subnets
+  task_subnets   = data.terraform_remote_state.common.outputs.common_vpc_private_subnets
+
+  additional_security_groups = [aws_security_group.test-sg.id]
+
+  enable_public_lb       = false
+  enable_local_discovery = false
+
+  tags = {
+    Environment = terraform.workspace
+    Application = "foo"
+  }
+}


### PR DESCRIPTION
`secrets` in ecs task definition allow the ecs task to fetch encrypted parameters from ssm parameter store without disclosing it to other aws services (like the UI) ([docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-parameters.html)).

This PR adds the ability to easily define secret injection using the `ecs-fargate-service` module.  
To do so one should define a map with the target environment variable as key and the ssm path as value.

```hcl
  secrets = {
    ENV_VARIABLE_NAME = "/path/in/ssm"
  }
```

Behind the hood it will configure the service task execution role to allow the retrieval and the decryption of secrets by the ecs platform.