### PR TITLE
Add additional configuration option for datadog agent

### DIFF
--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -160,7 +160,21 @@ locals {
         { name : "DD_LOGS_INJECTION", value : tostring(var.enable_datadog_logs_injection) },
         { name : "DD_SERVICE", value: var.service_name},
         { name : "DD_DOGSTATSD_MAPPER_PROFILES", value: var.datadog_mapper }
-              ]
+      ],
+      logConfiguration: var.collect_datadog_agent_logs ? {
+      logDriver : "awsfirelens",
+      options : {
+        Name : "datadog",
+        apikey : var.datadog_api_key,
+        Host : "http-intake.logs.datadoghq.eu",
+        TLS : "on",
+        provider : "ecs",
+        dd_service : var.service_name,
+        dd_source : "datadog-agent",
+        dd_message_key : "log",
+        dd_tags : join(",", [for k, v in var.tags : format("%s:%s", k, v)])
+        }
+      }: null
     }] :
     []
   )

--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -145,7 +145,7 @@ locals {
     var.enable_datadog_agent ?
     [{
       name : "datadog-agent",
-      image : "public.ecr.aws/datadog/agent:latest",
+      image : var.datadog_agent_image_tag,
       memory : 256,
       cpu : 0,
       environment : [

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -67,6 +67,10 @@ variable "availability_sidecar_enable" {
 variable "availability_sidecar_image" {
   default = "812957082909.dkr.ecr.eu-central-1.amazonaws.com/observability-tools:8c06fd0"
 }
+variable "datadog_agent_image_tag" {
+  default = "public.ecr.aws/datadog/agent:latest"
+  type    = string
+}
 variable "healthcheck_path" {
   default = ""
 }

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -71,6 +71,11 @@ variable "datadog_agent_image_tag" {
   default = "public.ecr.aws/datadog/agent:latest"
   type    = string
 }
+variable "collect_datadog_agent_logs"{
+  default = false
+  type    = bool
+}
+
 variable "healthcheck_path" {
   default = ""
 }


### PR DESCRIPTION
- Add the option to override the datadog image ref: useful when we need a different image distribution or when we need to bake some configuration files into it.
- Add the option to collect agent logs: useful when we need to debug the agent configuration.