### PR TITLE
feat: allow to pass multiple policy arn to task role

### DIFF
--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -188,15 +188,12 @@ resource "aws_iam_role" "task_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "custom_policy" {
-  # When using a custom policy, you may encounter the following error:
-  #   The "count" value depends on resource attributes that cannot be determined
-  # I didn't find a way to fix this.
-  # The workaround is to create the policy first (using tarraform apply -target=) 
-  # then finalize the attachment to the service
-  count = (var.task_role_policy_arn == null ? 0 : 1)
-
+  # The "for_each" value depends on resource attributes that cannot be determined until apply,
+  # so Terraform cannot predict how many instances will be created.
+  # To work around this, use the -target argument to first apply only the resources that the for_each depends on.
+  for_each   = toset(var.task_role_policies_arn)
   role       = aws_iam_role.task_role.name
-  policy_arn = var.task_role_policy_arn
+  policy_arn = each.value
 }
 
 resource "aws_iam_role" "execution_role" {

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -31,9 +31,9 @@ variable "platform_version" {
 variable "desired_tasks" {
   default = 1
 }
-variable "task_role_policy_arn" {
+variable "task_role_policies_arn" {
   default = null
-  type    = string
+  type    = list
 }
 variable "lb_subnets" {
   description = "list of subnet IDs for the public LB"


### PR DESCRIPTION
The `ecs-fargate-service` module currently only supports one IAM policy to be defined per task role which was ok until now but Bali needs a second policy.

The migration is painless as terraform will just recreate a new policy attachement.

PR to merge just after this one: 
- https://github.com/sencrop/sencrop-bali-api/pull/1351
- https://github.com/sencrop/sencrop-demeter-api/pull/328
- https://github.com/sencrop/dsp/pull/330
- https://github.com/sencrop/Sisyphe/pull/190