### PR TITLE
feat: add ecr repository common module

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,18 @@ TF_WORKSPACE=test terraform destroy -target=module.test_names
 - always destroy what you do at the end of the tests
 
 
+
+## ECR repository
+
+Configure an Elastic Container Registry with the standard lifecycle policy which will:
+
+- keep the last 25 production build
+- keep the last 50 tagged build (mostly preproduction build)
+- expire any untagged image after 7 days
+
+```hcl
+module "image_repository" {
+  source = "github.com/sencrop/terraform-modules//ecr-repository"
+  name   = "myimage"
+}
+```

--- a/ecr-repository/common_policy.json
+++ b/ecr-repository/common_policy.json
@@ -1,0 +1,43 @@
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep last 25 production images",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": ["v"],
+                "countType": "imageCountMoreThan",
+                "countNumber": 25
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 2,
+            "description": "Keep last 50 tagged images",
+            "selection": {
+                "tagStatus": "tagged",
+                "countType": "imageCountMoreThan",
+                "countNumber": 50
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 3,
+            "description": "Expire untagged images older than 7 days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber":7
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+

--- a/ecr-repository/repository.tf
+++ b/ecr-repository/repository.tf
@@ -1,0 +1,18 @@
+resource "aws_ecr_repository" "repository" {
+  name                 = var.name
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    "terraform.managed" = "true"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "common_policy" {
+  repository = aws_ecr_repository.repository.name
+  policy     = file("${path.module}/common_policy.json")
+}
+

--- a/ecr-repository/variables.tf
+++ b/ecr-repository/variables.tf
@@ -1,0 +1,3 @@
+variable "name" {
+  type = string
+}


### PR DESCRIPTION
This PR creates a common module to manage ecr repository. Today ecr repositories are unmanaged, which at first is not that bad as we don't need to create a new one that much often. However the configuration of our repository could be improved, especially they are all missing a lifecycle rule, which automates the expire of old images.

There is two issue with this:
- one day we will reach the maximum number of images allowed per repository (10k, `sencrop-api-nestjs` has 2k images)
- we pay for the storage of those old images that we will never use

![image](https://user-images.githubusercontent.com/779844/207102924-731f33e4-f636-45e8-9922-c411827755ef.png)

This PR introduces a simple `ecr-repository` module which will help us manage the container image lifecycle with the following rules:
- last 25 prod build will be preserved
- last 50 tagged build will be preserved (hence includes preprod build)
- untagged image (this should not happen outside of manual operation) will be expired after 7 days

