### PR TITLE
feat(lb): change lb strategy

### DIFF
--- a/ecs-fargate-service/lb.tf
+++ b/ecs-fargate-service/lb.tf
@@ -96,6 +96,8 @@ resource "aws_alb_target_group" "lb" {
   vpc_id      = var.vpc_id
   target_type = "ip"
 
+  load_balancing_algorithm_type = var.lb_algorithm_type
+
   health_check {
     path     = var.healthcheck_path
     interval = var.healthcheck_interval

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -103,7 +103,6 @@ resource "aws_alb_target_group" "lb_priv" {
 
   # avoid overloading a loaded host
   load_balancing_algorithm_type = "least_outstanding_requests"
-  slow_start = 30  # seconds before sending full share of requests to a new target
 
   health_check {
     path                = var.healthcheck_path

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -101,8 +101,7 @@ resource "aws_alb_target_group" "lb_priv" {
   vpc_id      = var.vpc_id
   target_type = "ip"
 
-  # avoid overloading a loaded host
-  load_balancing_algorithm_type = "least_outstanding_requests"
+  load_balancing_algorithm_type = var.lb_algorithm_type
 
   health_check {
     path                = var.healthcheck_path

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -101,7 +101,7 @@ resource "aws_alb_target_group" "lb_priv" {
   vpc_id      = var.vpc_id
   target_type = "ip"
 
-  # avoid oveerloading a loaded host
+  # avoid overloading a loaded host
   load_balancing_algorithm_type = "least_outstanding_requests"
   slow_start = 30  # seconds before sending full share of requests to a new target
 

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -101,6 +101,10 @@ resource "aws_alb_target_group" "lb_priv" {
   vpc_id      = var.vpc_id
   target_type = "ip"
 
+  # avoid oveerloading a loaded host
+  load_balancing_algorithm_type = "least_outstanding_requests"
+  slow_start = 30  # seconds before sending full share of requests to a new target
+
   health_check {
     path                = var.healthcheck_path
     interval            = var.healthcheck_interval

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -247,3 +247,7 @@ variable "datadog_mapper" {
   description = "Where to put some inline mappings between metrics emitted by some software and Datadog. Used only for Airflow as of now."
 }
 
+variable "lb_algorithm_type" {
+  default = "round_robin"
+  description = "Possible values 'round_robin' or 'least_outstanding_requests'. Applies to any type of LB (public or private)."
+}


### PR DESCRIPTION
Default LB traffic distribution is round-robin. There's an alternative algo, [Least Outstanding Requests](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#modify-routing-algorithm), which can avoid overloading a loaded host.

This may have the drawback that a broken host, returning HTTP500 quickly for any reason, will "attract" the traffic to itself. Since we have health-checks it may not be a risk too high.

This PR creates a variable to set it on LBs.

