### PR TITLE
add the dd agent config to expose the http endpoint for otlp trace ingestion

### DIFF
--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -23,14 +23,14 @@ data "aws_region" "current" {}
 
 locals {
 
-  mappings = var.ports == [] ? (var.port == 0 ? [] : [var.port]) : var.ports
-  dd_src_code_integration_tags = var.enable_datadog_src_code_integration ? {"git.commit.sha" = var.commit_sha, "git.repository_url" = var.repository_url} : {}
+  mappings                     = var.ports == [] ? (var.port == 0 ? [] : [var.port]) : var.ports
+  dd_src_code_integration_tags = var.enable_datadog_src_code_integration ? { "git.commit.sha" = var.commit_sha, "git.repository_url" = var.repository_url } : {}
 
   default_env_vars = {
-    DD_SERVICE           = var.service_name
-    DD_VERSION           = var.app_version
-    DD_ENV               = lower(terraform.workspace)
-    DD_TAGS              = join(",", [for k, v in merge(local.dd_src_code_integration_tags, var.dd_tags) : format("%s:%s", k, v)])
+    DD_SERVICE = var.service_name
+    DD_VERSION = var.app_version
+    DD_ENV     = lower(terraform.workspace)
+    DD_TAGS    = join(",", [for k, v in merge(local.dd_src_code_integration_tags, var.dd_tags) : format("%s:%s", k, v)])
   }
 
   main_task_env_vars = merge(local.default_env_vars, var.env_vars)
@@ -90,7 +90,7 @@ locals {
         dd_service : var.service_name,
         dd_source : var.datadog_log_source,
         dd_message_key : "log",
-        dd_tags : join(",", [for k, v in merge({version: var.app_version}, var.tags) : format("%s:%s", k, v)])
+        dd_tags : join(",", [for k, v in merge({ version : var.app_version }, var.tags) : format("%s:%s", k, v)])
       }
     }
   )
@@ -171,7 +171,7 @@ locals {
         { name : "DD_LOGS_INJECTION", value : tostring(var.enable_datadog_logs_injection) },
         { name : "DD_SERVICE", value : var.service_name },
         { name : "DD_DOGSTATSD_MAPPER_PROFILES", value : var.datadog_mapper },
-        { name: "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT", value: tostring(var.datadog_receiver_otlp_http_endpoint)}
+        { name : "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT", value : tostring(var.datadog_receiver_otlp_http_endpoint) }
       ],
       logConfiguration : var.collect_datadog_agent_logs ? {
         logDriver : "awsfirelens",

--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -170,7 +170,8 @@ locals {
         { name : "DD_ENV", value : lower(terraform.workspace) },
         { name : "DD_LOGS_INJECTION", value : tostring(var.enable_datadog_logs_injection) },
         { name : "DD_SERVICE", value : var.service_name },
-        { name : "DD_DOGSTATSD_MAPPER_PROFILES", value : var.datadog_mapper }
+        { name : "DD_DOGSTATSD_MAPPER_PROFILES", value : var.datadog_mapper },
+        { name: "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT", value: tostring(var.datadog_receiver_otlp_http_endpoint)}
       ],
       logConfiguration : var.collect_datadog_agent_logs ? {
         logDriver : "awsfirelens",

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -195,6 +195,10 @@ variable "enable_datadog_logs_injection" {
   default     = false
   description = "To inject trace IDs, span IDs, env, service, and version in the logs. See https://docs.datadoghq.com/tracing/connect_logs_and_traces/"
 }
+variable "datadog_receiver_otlp_http_endpoint" {
+  default = "localhost:4318"
+  description = "HTTP endpoint of the datadog agent used to receive traces in OpenTelemetry format"
+}
 variable "enable_datadog_src_code_integration" {
   type        = bool
   default     = false

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -19,7 +19,7 @@ variable "service_name" {}
 // currently only used to set DD_VERSION
 // TODO: make it mandatory once it is set everywhere
 variable "app_version" {
-  type = string
+  type    = string
   default = ""
 }
 variable "port" {
@@ -39,7 +39,7 @@ variable "desired_tasks" {
 }
 variable "task_role_policies_arn" {
   default = []
-  type    = list
+  type    = list(any)
 }
 variable "lb_subnets" {
   description = "list of subnet IDs for the public LB"
@@ -146,8 +146,8 @@ variable "tags" {
   default = {}
 }
 variable "dd_tags" {
-  default = {}
-  type = map(string)
+  default     = {}
+  type        = map(string)
   description = "tags added to the DD_TAGS environment variable of the main task"
 }
 
@@ -196,7 +196,7 @@ variable "enable_datadog_logs_injection" {
   description = "To inject trace IDs, span IDs, env, service, and version in the logs. See https://docs.datadoghq.com/tracing/connect_logs_and_traces/"
 }
 variable "datadog_receiver_otlp_http_endpoint" {
-  default = "localhost:4318"
+  default     = "localhost:4318"
   description = "HTTP endpoint of the datadog agent used to receive traces in OpenTelemetry format"
 }
 variable "enable_datadog_src_code_integration" {
@@ -205,13 +205,13 @@ variable "enable_datadog_src_code_integration" {
   description = "Enable the (APM) source code integration, commit_sha and repository_url should be defined as well"
 }
 variable "commit_sha" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "git commit sha of the configured service version"
 }
 variable "repository_url" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "http url of the git repository"
 }
 variable "public_lb_access_logs_bucket" {
@@ -252,6 +252,6 @@ variable "datadog_mapper" {
 }
 
 variable "lb_algorithm_type" {
-  default = "round_robin"
+  default     = "round_robin"
   description = "Possible values 'round_robin' or 'least_outstanding_requests'. Applies to any type of LB (public or private)."
 }


### PR DESCRIPTION
Currently trying to send the Prisma traces to Datadog which are in otel format, I need to expose the http endpoint for ingestion on the agent through the env var.