### PR TITLE
fix(security): mark env vars as sensitive

### DIFF
--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -53,6 +53,7 @@ variable "additional_security_groups" {
 variable "env_vars" {
   default = {}
   type    = map(string)
+  sensitive = true
 }
 variable "secrets" {
   default = {}

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -55,7 +55,7 @@ variable "env_vars" {
   type    = map(string)
   sensitive = true
 }
-variable "secrets" {
+variable "secrets_ssm_paths" {
   default = {}
   type    = map(string)
 }
@@ -167,6 +167,7 @@ variable "logs" {
 }
 variable "datadog_api_key" {
   default = ""
+  sensitive = true
 }
 variable "logs_json" {
   default     = false

--- a/test/test_secrets.tf
+++ b/test/test_secrets.tf
@@ -7,7 +7,7 @@ module "test_secrets" {
   mem          = 512
   port         = 8080
 
-  secrets = {
+  secrets_ssm_paths = {
     "MY_LITTLE_SECRET" : "/tf/test/my-little-secret",
     "MY_BIG_SECRET"    : "/tf/test/my-big-secret"
 


### PR DESCRIPTION
Env vars are sometimes printed in tf logs which we want to avoid as they often contain secrets.