### PR TITLE
remove useless sensitive marker on secrets var

### DIFF
--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -63,9 +63,9 @@ locals {
     environment : [
       for k, v in local.main_task_env_vars : { name : k, value : v }
     ],
-    secrets : sensitive([
+    secrets : [
       for env_var, ssm_path in var.secrets_ssm_paths : { name : env_var, valueFrom : format("arn:aws:ssm:%s:%s:parameter%s", local.region, local.account_id, ssm_path) }
-    ]),
+    ],
     logConfiguration : local.logConf
   }]
 

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -51,8 +51,8 @@ variable "additional_security_groups" {
   default     = []
 }
 variable "env_vars" {
-  default = {}
-  type    = map(string)
+  default   = {}
+  type      = map(string)
   sensitive = true
 }
 variable "secrets_ssm_paths" {
@@ -166,7 +166,7 @@ variable "logs" {
   description = "Should be \"cloudwatch\" or \"datadog\"."
 }
 variable "datadog_api_key" {
-  default = ""
+  default   = ""
   sensitive = true
 }
 variable "logs_json" {

--- a/test/test_secrets.tf
+++ b/test/test_secrets.tf
@@ -10,7 +10,6 @@ module "test_secrets" {
   secrets_ssm_paths = {
     "MY_LITTLE_SECRET" : "/tf/test/my-little-secret",
     "MY_BIG_SECRET"    : "/tf/test/my-big-secret"
-
   }
 
   ecs_cluster_id = data.terraform_remote_state.common.outputs.main_ecs_cluster_id


### PR DESCRIPTION
`secrets` actually just contain the ssm paths to secrets so we don't need to make those sensitive.