### PR TITLE
feat: configure scale in and out cooldown

### DIFF
--- a/ecs-fargate-service/autoscaling.tf
+++ b/ecs-fargate-service/autoscaling.tf
@@ -25,7 +25,9 @@ resource "aws_appautoscaling_policy" "ecs_policy" {
   service_namespace  = aws_appautoscaling_target.ecs_service[0].service_namespace
 
   target_tracking_scaling_policy_configuration {
-    target_value = var.autoscale_cpu_target
+    target_value       = var.autoscale_cpu_target
+    scale_in_cooldown  = var.autoscale_scale_in_cooldown
+    scale_out_cooldown = var.autoscale_scale_out_cooldown
 
     predefined_metric_specification {
       predefined_metric_type = "ECSServiceAverageCPUUtilization"

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -144,11 +144,13 @@ variable "autoscale_cpu_target" {
   default = 80
 }
 variable "autoscale_scale_in_cooldown" {
-  default     = 3600
+  default     = 300
+  type        = number
   description = "Amount of time, in seconds, after a scale in activity completes before another scale in activity can start"
 }
 variable "autoscale_scale_out_cooldown" {
   default     = 300
+  type        = number
   description = "Amount of time, in seconds, after a scale out activity completes before another scale out activity can start"
 }
 variable "tags" {

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -143,6 +143,14 @@ variable "autoscale_min_tasks" {
 variable "autoscale_cpu_target" {
   default = 80
 }
+variable "autoscale_scale_in_cooldown" {
+  default     = 3600
+  description = "Amount of time, in seconds, after a scale in activity completes before another scale in activity can start"
+}
+variable "autoscale_scale_out_cooldown" {
+  default     = 300
+  description = "Amount of time, in seconds, after a scale out activity completes before another scale out activity can start"
+}
 variable "tags" {
   default = {}
 }


### PR DESCRIPTION
Default:
-  5 minutes for scale out (waiting for load to stabilize as CPU can burst on start up)
-  60 minutes for scale in (avoid scaling in during a peak hour)

More about this: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-auto-scaling.html