### PR TITLE
feat: tune default start/stop sequence

### DIFF
--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -43,6 +43,7 @@ locals {
     name : var.service_name,
     networkMode : "awsvpc",
     mountPoints : [],
+    stopTimeout : var.stop_timeout
     ulimits : (
       var.docker_ulimits == [] ?
       null :

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -90,8 +90,9 @@ variable "healthcheck_interval" {
   default = 5
 }
 variable "healthcheck_grace_period" {
-  default = 60
+  default = 30
   type    = number
+  description = "Failed health check won't be accounted to determine the health status of the task during the grace period"
 }
 variable "healthcheck_timeout" {
   default = 5
@@ -116,7 +117,9 @@ variable "public_lb_dns_name" {
   default = ""
 }
 variable "public_lb_idle_timeout" {
-  default = 60
+  type        = number
+  default     = 60
+  description = "How long in seconds the load balancer will keep an idle connection open with the backend"
 }
 variable "enable_public_lb" {
   default = true
@@ -161,9 +164,9 @@ variable "dd_tags" {
   type        = map(string)
   description = "tags added to the DD_TAGS environment variable of the main task"
 }
-
 variable "deregistration_delay" {
-  description = "load balancer target group deregistration"
+  type        = number
+  description = "How long in second a load balancer will keep a target in DRAINING state before removing it from the targets. Most of the time this should be aligned with the idle timeout."
   default     = 60
 }
 variable "docker_ulimits" {
@@ -249,7 +252,9 @@ variable "private_lb_dns_name" {
   default = ""
 }
 variable "private_lb_idle_timeout" {
-  default = 60
+  type        = number
+  default     = 60
+  description = "How long in seconds the load balancer will keep an idle connection open with the backend"
 }
 variable "lb_private_additional_security_groups" {
   description = "additional security groups for private LB"
@@ -266,4 +271,9 @@ variable "datadog_mapper" {
 variable "lb_algorithm_type" {
   default     = "round_robin"
   description = "Possible values 'round_robin' or 'least_outstanding_requests'. Applies to any type of LB (public or private)."
+}
+variable "stop_timeout" {
+  type        = number
+  default     = 5
+  description = "How long in seconds the orchestrator will wait to send a SIGKILL after a SIGTERM, max 120 seconds"
 }

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -90,7 +90,7 @@ variable "healthcheck_interval" {
   default = 5
 }
 variable "healthcheck_grace_period" {
-  default = null
+  default = 60
   type    = number
 }
 variable "healthcheck_timeout" {

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -87,7 +87,7 @@ variable "healthcheck_path" {
   default = ""
 }
 variable "healthcheck_interval" {
-  default = 30
+  default = 5
 }
 variable "healthcheck_grace_period" {
   default = null
@@ -164,7 +164,7 @@ variable "dd_tags" {
 
 variable "deregistration_delay" {
   description = "load balancer target group deregistration"
-  default     = 300
+  default     = 60
 }
 variable "docker_ulimits" {
   description = "see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Ulimit.html"


### PR DESCRIPTION
- load balancer health check will be performed every 5 seconds (previously every 30 seconds), this will speed up the default minimum time for a container to be considered ready from 90 seconds to 15 seconds and the time to detect unhealthy tasks. 
- load balancer deregistration delay (how long the load balancer keeps a task in draining state) is lowered to 60 seconds (previously 5 minutes) as common applications don't need to maintain connection for such a long time. This value should be aligned with the idle timeout (how long a backend connection is kept alive waiting for a backend response) which already has a default value at 60 seconds.
- default grace period for ECS task is set to 30 seconds so tasks are not prematurely killed during start up (was previously unset and the default is 0 second, this parameter would have protected demeter task start up during incident #127). With this settings a new task has up to 45 seconds to answer the health check before getting killed (30 seconds of grace period + 3 consecutive health check failure)
- `stopTermination` parameter can now be overridden so we can control how long application have to exit after receiving SIGTERM (default is set to 5 seconds). It's important to note that this timeout only applies after the deregistration of the task from the loadbalancer (see the task lifecyle diagram below).

**[ECS task lifecycle](https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/)**
![image](https://github.com/sencrop/terraform-modules/assets/779844/3b5ff10a-4a67-4ac0-9979-c7cccb175c05)


Configured values for critical apps need to be reviewed before merging this PR:
- data-capture
- demeter
- bali
