### PR TITLE
enable datadog runtime metrics support

### DIFF
--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -27,10 +27,11 @@ locals {
   dd_src_code_integration_tags = var.enable_datadog_src_code_integration ? { "git.commit.sha" = var.commit_sha, "git.repository_url" = var.repository_url } : {}
 
   default_env_vars = {
-    DD_SERVICE = var.service_name
-    DD_VERSION = var.app_version
-    DD_ENV     = lower(terraform.workspace)
-    DD_TAGS    = join(",", [for k, v in merge(local.dd_src_code_integration_tags, var.dd_tags) : format("%s:%s", k, v)])
+    DD_SERVICE                 = var.service_name
+    DD_VERSION                 = var.app_version
+    DD_ENV                     = lower(terraform.workspace)
+    DD_TAGS                    = join(",", [for k, v in merge(local.dd_src_code_integration_tags, var.dd_tags) : format("%s:%s", k, v)])
+    DD_RUNTIME_METRICS_ENABLED = var.enable_datadog_runtime_metrics
   }
 
   main_task_env_vars = merge(local.default_env_vars, var.env_vars)
@@ -168,6 +169,7 @@ locals {
         { name : "DD_APM_ENABLED", value : tostring(var.enable_datadog_agent_apm) },
         { name : "DD_APM_IGNORE_RESOURCES", value : join(",", var.datadog_apm_ignore_ressources) },
         { name : "DD_APM_NON_LOCAL_TRAFFIC", value : tostring(var.enable_datadog_non_local_apm) },
+        { name : "DD_DOGSTATSD_NON_LOCAL_TRAFFIC", value : tostring(var.enable_datadog_dogstatsd_non_local_traffic) },
         { name : "DD_ENV", value : lower(terraform.workspace) },
         { name : "DD_LOGS_INJECTION", value : tostring(var.enable_datadog_logs_injection) },
         { name : "DD_SERVICE", value : var.service_name },
@@ -318,4 +320,3 @@ resource "aws_service_discovery_service" "name" {
     failure_threshold = 1
   }
 }
-

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -82,7 +82,10 @@ variable "collect_datadog_agent_logs" {
   default = false
   type    = bool
 }
-
+variable "enable_datadog_runtime_metrics" {
+  default = false
+  type    = bool
+}
 variable "healthcheck_path" {
   default = ""
 }
@@ -90,13 +93,13 @@ variable "healthcheck_interval" {
   default = 5
 }
 variable "healthcheck_grace_period" {
-  default = 30
-  type    = number
+  default     = 30
+  type        = number
   description = "Failed health check won't be accounted to determine the health status of the task during the grace period"
 }
 variable "healthcheck_timeout" {
-  default = 2
-  type = number
+  default     = 2
+  type        = number
   description = "timeout range must be between 2 and 120 seconds"
 }
 variable "healthcheck_matcher" {
@@ -203,6 +206,10 @@ variable "enable_datadog_agent_apm" {
 variable "enable_datadog_non_local_apm" {
   default     = false
   description = "To enable APM data collection in datadog agent with APM features."
+}
+variable "enable_datadog_dogstatsd_non_local_traffic" {
+  default     = false
+  description = "To enable DogStatsD data collection in datadog agent"
 }
 variable "datadog_apm_ignore_ressources" {
   default     = []


### PR DESCRIPTION
Should allow the use of runtime metrics for both node.js and python ECS based services:
- https://docs.datadoghq.com/tracing/metrics/runtime_metrics/nodejs/?tab=environmentvariables
- https://docs.datadoghq.com/tracing/metrics/runtime_metrics/python