### PR TITLE
Add port option for healthchecks

### DIFF
--- a/ecs-fargate-service/lb.tf
+++ b/ecs-fargate-service/lb.tf
@@ -99,7 +99,8 @@ resource "aws_alb_target_group" "lb" {
   load_balancing_algorithm_type = var.lb_algorithm_type
 
   health_check {
-    path     = var.healthcheck_port ? var.healthcheck_port : var.port
+    path     = var.healthcheck_path
+    port     = var.healthcheck_port ? var.healthcheck_port : var.port
     interval = var.healthcheck_interval
     timeout  = var.healthcheck_timeout
     matcher  = var.healthcheck_matcher

--- a/ecs-fargate-service/lb.tf
+++ b/ecs-fargate-service/lb.tf
@@ -99,7 +99,7 @@ resource "aws_alb_target_group" "lb" {
   load_balancing_algorithm_type = var.lb_algorithm_type
 
   health_check {
-    path     = var.healthcheck_path
+    path     = var.healthcheck_port ? var.healthcheck_port : var.port
     interval = var.healthcheck_interval
     timeout  = var.healthcheck_timeout
     matcher  = var.healthcheck_matcher

--- a/ecs-fargate-service/lb.tf
+++ b/ecs-fargate-service/lb.tf
@@ -100,7 +100,7 @@ resource "aws_alb_target_group" "lb" {
 
   health_check {
     path     = var.healthcheck_path
-    port     = var.healthcheck_port ? var.healthcheck_port : var.port
+    port     = var.healthcheck_port != 0 ? var.healthcheck_port : var.port
     interval = var.healthcheck_interval
     timeout  = var.healthcheck_timeout
     matcher  = var.healthcheck_matcher

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -105,6 +105,7 @@ resource "aws_alb_target_group" "lb_priv" {
 
   health_check {
     path                = var.healthcheck_path
+    port                = var.healthcheck_port ? var.healthcheck_port : var.port
     interval            = var.healthcheck_interval
     timeout             = var.healthcheck_timeout
     matcher             = var.healthcheck_matcher

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -105,7 +105,7 @@ resource "aws_alb_target_group" "lb_priv" {
 
   health_check {
     path                = var.healthcheck_path
-    port                = var.healthcheck_port ? var.healthcheck_port : var.port
+    port                = var.healthcheck_port != 0 ? var.healthcheck_port : var.port
     interval            = var.healthcheck_interval
     timeout             = var.healthcheck_timeout
     matcher             = var.healthcheck_matcher

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -89,6 +89,7 @@ variable "enable_datadog_runtime_metrics" {
 variable "healthcheck_path" {
   default = ""
 }
+variable "healthcheck_port" {}
 variable "healthcheck_interval" {
   default = 5
 }

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -89,7 +89,9 @@ variable "enable_datadog_runtime_metrics" {
 variable "healthcheck_path" {
   default = ""
 }
-variable "healthcheck_port" {}
+variable "healthcheck_port" {
+  default = 0
+}
 variable "healthcheck_interval" {
   default = 5
 }


### PR DESCRIPTION
We have a use-case for deploying the Kong gateway where the main port (8000) is different than the one we need to use for the healthcheck (8001 as it belongs to the gateway admin API)