### PR TITLE
fix the use of a dynamic ingress block in a ressource using count

### DIFF
--- a/ecs-fargate-service/lb.tf
+++ b/ecs-fargate-service/lb.tf
@@ -38,7 +38,7 @@ resource "aws_security_group" "lb_to_service" {
   vpc_id      = var.vpc_id
 
   dynamic "ingress" {
-    for_each = toset(concat(var.ports, [var.port]))
+    for_each = var.enable_private_lb ? toset(concat(var.ports, [var.port])) : []
     content {
       protocol        = "tcp"
       from_port       = ingress.value

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -49,7 +49,7 @@ resource "aws_security_group" "lb_priv_to_service" {
   vpc_id      = var.vpc_id
 
   dynamic "ingress" {
-    for_each = toset(concat(var.ports, [var.port]))
+    for_each = var.enable_private_lb ? toset(concat(var.ports, [var.port])) : []
     content {
       protocol        = "tcp"
       from_port       = ingress.value


### PR DESCRIPTION
It seems the dynamic block is always evaluated even if the count is set to 0 which breaks deployments when it is.