### PR TITLE
Set default healthcheck port back to traffic-port

### DIFF
--- a/ecs-fargate-service/lb.tf
+++ b/ecs-fargate-service/lb.tf
@@ -103,7 +103,7 @@ resource "aws_alb_target_group" "lb" {
 
   health_check {
     path     = var.healthcheck_path
-    port     = var.healthcheck_port != 0 ? var.healthcheck_port : var.port
+    port     = var.healthcheck_port != "traffic-port" ? var.healthcheck_port : var.port
     interval = var.healthcheck_interval
     timeout  = var.healthcheck_timeout
     matcher  = var.healthcheck_matcher

--- a/ecs-fargate-service/lb.tf
+++ b/ecs-fargate-service/lb.tf
@@ -103,7 +103,7 @@ resource "aws_alb_target_group" "lb" {
 
   health_check {
     path     = var.healthcheck_path
-    port     = var.healthcheck_port != "traffic-port" ? var.healthcheck_port : var.port
+    port     = var.healthcheck_port
     interval = var.healthcheck_interval
     timeout  = var.healthcheck_timeout
     matcher  = var.healthcheck_matcher

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -108,7 +108,7 @@ resource "aws_alb_target_group" "lb_priv" {
 
   health_check {
     path                = var.healthcheck_path
-    port                = var.healthcheck_port != "traffic-port" ? var.healthcheck_port : var.port
+    port                = var.healthcheck_port
     interval            = var.healthcheck_interval
     timeout             = var.healthcheck_timeout
     matcher             = var.healthcheck_matcher

--- a/ecs-fargate-service/lb_private.tf
+++ b/ecs-fargate-service/lb_private.tf
@@ -108,7 +108,7 @@ resource "aws_alb_target_group" "lb_priv" {
 
   health_check {
     path                = var.healthcheck_path
-    port                = var.healthcheck_port != 0 ? var.healthcheck_port : var.port
+    port                = var.healthcheck_port != "traffic-port" ? var.healthcheck_port : var.port
     interval            = var.healthcheck_interval
     timeout             = var.healthcheck_timeout
     matcher             = var.healthcheck_matcher

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -92,7 +92,7 @@ variable "healthcheck_path" {
   default = ""
 }
 variable "healthcheck_port" {
-  default = 0
+  default = "traffic-port"
 }
 variable "healthcheck_interval" {
   default = 5


### PR DESCRIPTION
Use the actual `traffic-port` default value when necessary rather than manually adding the value corresponding to it.
cf: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#health_check