### PR TITLE
[SENP-699] feat(ecs-fargate-service): allow command exec

### DIFF
--- a/ecs-fargate-service/policies/ecs_exec.json
+++ b/ecs-fargate-service/policies/ecs_exec.json
@@ -1,0 +1,15 @@
+{
+   "Version": "2012-10-17",
+   "Statement": [
+       {
+       "Effect": "Allow",
+       "Action": [
+            "ssmmessages:CreateControlChannel",
+            "ssmmessages:CreateDataChannel",
+            "ssmmessages:OpenControlChannel",
+            "ssmmessages:OpenDataChannel"
+       ],
+      "Resource": "*"
+      }
+   ]
+}

--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -211,6 +211,12 @@ resource "aws_iam_role_policy_attachment" "custom_policy" {
   policy_arn = each.value
 }
 
+resource "aws_iam_role_policy" "ecs_exec_policy" {
+  count  = var.enable_execute_command ? 1 : 0
+  role   = aws_iam_role.task_role.name
+  policy = file("${path.module}/policies/ecs_exec.json")
+}
+
 resource "aws_iam_role" "execution_role" {
   count               = (local.needs_execution_role ? 1 : 0)
   name                = "${var.service_name}-${terraform.workspace}-task-execution-role"
@@ -255,13 +261,14 @@ resource "aws_ecs_task_definition" "task" {
 
 # service definition
 resource "aws_ecs_service" "service" {
-  count            = var.task_definition_only == true ? 0 : 1
-  name             = var.service_name
-  cluster          = var.ecs_cluster_id
-  task_definition  = aws_ecs_task_definition.task.arn
-  desired_count    = var.desired_tasks
-  launch_type      = "FARGATE"
-  platform_version = var.platform_version
+  count                  = var.task_definition_only == true ? 0 : 1
+  name                   = var.service_name
+  cluster                = var.ecs_cluster_id
+  task_definition        = aws_ecs_task_definition.task.arn
+  desired_count          = var.desired_tasks
+  launch_type            = "FARGATE"
+  platform_version       = var.platform_version
+  enable_execute_command = var.enable_execute_command
 
   network_configuration {
     security_groups = concat(

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -301,3 +301,8 @@ variable "fluent_bit_image_tag" {
   type    = string
   default = "812957082909.dkr.ecr.eu-central-1.amazonaws.com/public-ecr/aws-observability/aws-for-fluent-bit:2.19.0"
 }
+variable "enable_execute_command" {
+  type        = bool
+  default     = false
+  description = "Allow an operator to exec inisde containers using aws ecs execute-command"
+}


### PR DESCRIPTION
This PR introduce a new flag `enable_execute_command` that allow an operator to exec inside the task container.

```
aws ecs execute-command --cluster my-cluster \
    --task 5f78ae2c1bff49c3b7ef5af8eca243df \
    --container my-container \
    --interactive \
    --command "/bin/sh"
  ```
  
  The purpose of this flag is to be only turned on temporarily for debugging purpose.