### PR TITLE
[SENP-745] feat(ecs-fargate-service): add support for docker labels

### DIFF
--- a/ecs-fargate-service/service.tf
+++ b/ecs-fargate-service/service.tf
@@ -50,6 +50,7 @@ locals {
       null :
       var.docker_ulimits
     ),
+    dockerLabels: var.docker_labels,
     volumesFrom : (
       var.side_car_image == "" ?
       [] :

--- a/ecs-fargate-service/variables.tf
+++ b/ecs-fargate-service/variables.tf
@@ -111,6 +111,11 @@ variable "task_definition_only" {
   default     = false
   description = "When set to true only the task definition will be published"
 }
+variable "docker_labels" {
+  default = {}
+  type = map
+  description = "Labels added to the main task container at runtime"
+}
 /**************************************************
  * Service discovery
  * ***********************************************/


### PR DESCRIPTION
This can be used to configure Datadog integration that are not detected by the auto discovery (https://docs.datadoghq.com/containers/docker/integrations/?tab=dockeradv2).